### PR TITLE
Add Swift Package Manager Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,11 +36,9 @@ timeline.xctimeline
 playground.xcworkspace
  
 # Swift Package Manager
-#
-# Add this line if you want to avoid checking in source code from Swift Package Manager dependencies.
-# Packages/
-# Package.pins
 .build/
+.swiftpm
+Packages/
  
 # CocoaPods - Refactored to standalone file
  

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,21 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "MentionmeSwift",
+    products: [
+        .library(
+            name: "MentionmeSwift",
+            targets: [
+                "MentionmeSwift"
+            ]
+        )
+    ],
+    targets: [
+        .target(
+            name: "MentionmeSwift",
+            path: "MentionmeSwift"
+        )
+    ]
+)
+

--- a/README.md
+++ b/README.md
@@ -19,6 +19,16 @@ If you're interested in becoming a client, [please contact us first](https://blo
 
 ## Installation
 
+### Swift Package Manager
+
+Swift Package Manager is a dependency manager built into Xcode.
+
+If you are using Xcode 11 or higher, go to File / Swift Packages / Add Package Dependency... and enter package repository URL https://github.com/mention-me.git, then follow the instructions.
+
+To remove the dependency, select the project and open Swift Packages (which is next to Build Settings). You can add and remove packages from this tab.
+
+### CocoaPods
+
 MentionmeSwift is available through [CocoaPods](https://cocoapods.org). To install it, simply add the following line to your Podfile:
 
 ```ruby

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you're interested in becoming a client, [please contact us first](https://blo
 
 ## Installation
 
-### Swift Package Manager
+### Swift Package Manager
 
 Swift Package Manager is a dependency manager built into Xcode.
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,12 @@ If you're interested in becoming a client, [please contact us first](https://blo
 
 ### Swift Package Manager
 
-Swift Package Manager is a dependency manager built into Xcode.
-
-If you are using Xcode 11 or higher, go to File / Swift Packages / Add Package Dependency... and enter package repository URL https://github.com/mention-me.git, then follow the instructions.
-
-To remove the dependency, select the project and open Swift Packages (which is next to Build Settings). You can add and remove packages from this tab.
+To install **MentionmeSwift**, just add the package as a dependency in your `Package.swift` file.
+```swift
+dependencies: [
+    .package(url: "https://github.com/mention-me/ios-sdk.git", .branch("master"))
+]
+```
 
 ### CocoaPods
 


### PR DESCRIPTION
This PR adds support for Swift Package Manager.

I kept the import name the same as for cocoa pods so usage should be identical!