### PR TITLE
Pass segment through to the enrolment

### DIFF
--- a/Example/MentionmeSwift/EnrolReferrerViewController.swift
+++ b/Example/MentionmeSwift/EnrolReferrerViewController.swift
@@ -21,6 +21,7 @@ class EnrolReferrerViewController: UIViewController {
   var firstname = "Logan"
   var surname = "Smith"
   var email = "logansmith813@mention-me.com"
+  var segment = "vip"
   var privacyTermsString = ""
   var offer: MentionmeOffer?
   var shareLinks: [MentionmeShareLink]?
@@ -52,10 +53,13 @@ class EnrolReferrerViewController: UIViewController {
   }
 
   func checkIfReferrerCanEnrol() {
+    let parameters = MentionmeCustomerParameters(
+      emailAddress: email, firstname: firstname, surname: surname)
+    parameters.segment = segment
 
     //Check if the enrollment can even happen before trying to enrol the referrer
     Mentionme.shared.entryPointForReferrerEnrollment(
-      mentionmeReferrerEnrollmentRequest: MentionmeReferrerEnrollmentRequest(),
+      mentionmeReferrerEnrollmentRequest: MentionmeReferrerEnrollmentRequest(mentionmeCustomerParameters: parameters),
       situation: "app-check-enrol-referrer",
       success: { (url, defaultCallToActionString) in
 
@@ -82,6 +86,8 @@ class EnrolReferrerViewController: UIViewController {
     //Creating customer parameters with email , firstname and surname
     let parameters = MentionmeCustomerParameters(
       emailAddress: email, firstname: firstname, surname: surname)
+    parameters.segment = segment
+
     //Creating the customer request needed for the referrer enrolment.
     let request = MentionmeCustomerRequest(mentionmeCustomerParameters: parameters)
 

--- a/MentionmeSwift.podspec
+++ b/MentionmeSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MentionmeSwift'
-  s.version          = '1.2'
+  s.version          = '2.0'
   s.summary          = 'Supercharge your customer growth with referral marketing through Mention Me'
 
 # This description is used to generate tags and improve search results.
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
   s.author           = { 'mention-me' => 'appledeveloper@mention-me.com' }
   s.source           = { :git => 'https://github.com/mention-me/ios-sdk.git', :tag => s.version.to_s }
   
-  s.ios.deployment_target = '9.3'
+  s.ios.deployment_target = '11.0'
   s.swift_version = '5.0'
   s.source_files = 'MentionmeSwift/Classes/**/*'
   s.pod_target_xcconfig = { 'SWIFT_VERSION' => '5.0' }

--- a/MentionmeSwift/Classes/Requests/MentionmeReferrerEnrollmentRequest.swift
+++ b/MentionmeSwift/Classes/Requests/MentionmeReferrerEnrollmentRequest.swift
@@ -10,8 +10,13 @@ import Foundation
 
 public class MentionmeReferrerEnrollmentRequest: MentionmeRequest {
 
-  public override init() {
+  override init() {
     super.init()
+  }
+
+  public convenience init(mentionmeCustomerParameters: MentionmeCustomerParameters) {
+
+    self.init()
 
     super.method = MethodType.post
     super.urlSuffix = "referrer"


### PR DESCRIPTION
We'll now consume the `segment` in parameters passed to the enrolment requests. The example application has been updated to send the `vip` segment to the endpoints as a demonstration.

This also updates the `podspec` file to jump from `1.2` to `2.0`.