### PR TITLE
Include the MentionMeSwift library when building Example

### DIFF
--- a/Example/MentionmeSwift.xcodeproj/xcshareddata/xcschemes/MentionmeSwift-Example.xcscheme
+++ b/Example/MentionmeSwift.xcodeproj/xcshareddata/xcschemes/MentionmeSwift-Example.xcscheme
@@ -34,6 +34,20 @@
                ReferencedContainer = "container:MentionmeSwift.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "90331CCAC066107FE1AAE5A085EF7AE3"
+               BuildableName = "MentionmeSwift.framework"
+               BlueprintName = "MentionmeSwift"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
When building the example, it's helpful to rebuild the MentionMeSwift library too.