### PR TITLE
Fix segment not passed to entry point

### DIFF
--- a/Example/MentionmeSwift/EnrolReferrerViewController.swift
+++ b/Example/MentionmeSwift/EnrolReferrerViewController.swift
@@ -57,9 +57,11 @@ class EnrolReferrerViewController: UIViewController {
       emailAddress: email, firstname: firstname, surname: surname)
     parameters.segment = segment
 
+    let request = MentionmeReferrerEnrollmentRequest(mentionmeCustomerParameters: parameters)
+
     //Check if the enrollment can even happen before trying to enrol the referrer
     Mentionme.shared.entryPointForReferrerEnrollment(
-      mentionmeReferrerEnrollmentRequest: MentionmeReferrerEnrollmentRequest(mentionmeCustomerParameters: parameters),
+      mentionmeReferrerEnrollmentRequest: request,
       situation: "app-check-enrol-referrer",
       success: { (url, defaultCallToActionString) in
 

--- a/Example/MentionmeSwift/EnrolReferrerViewController.swift
+++ b/Example/MentionmeSwift/EnrolReferrerViewController.swift
@@ -31,7 +31,12 @@ class EnrolReferrerViewController: UIViewController {
 
     configureUI()
 
-    checkIfReferrerCanEnrol()
+    // There are two APIs you can use. The EntryPoint is the easiest to get started with - it returns a URL
+    // to render the Mention Me journey.
+    // You don't need to call this if you're using the Consumer API. We've left it in as a demo!
+    callEntryPointApiEnrollment()
+    // Alternatively, the Consumer API gives you the building blocks to assemble your own UI.
+    callConsumerApiEnrollment()
   }
 
   func configureUI() {
@@ -52,7 +57,7 @@ class EnrolReferrerViewController: UIViewController {
 
   }
 
-  func checkIfReferrerCanEnrol() {
+  func callEntryPointApiEnrollment() {
     let parameters = MentionmeCustomerParameters(
       emailAddress: email, firstname: firstname, surname: surname)
     parameters.segment = segment
@@ -65,8 +70,9 @@ class EnrolReferrerViewController: UIViewController {
       situation: "app-check-enrol-referrer",
       success: { (url, defaultCallToActionString) in
 
-        //if success then enrol referrer
-        self.enrolReferrer()
+        // If successful, you can now use the URL and the Call to Action in your UI.
+        print(url)
+        print(defaultCallToActionString)
 
       },
       failure: { (error) in
@@ -83,7 +89,7 @@ class EnrolReferrerViewController: UIViewController {
     }
   }
 
-  func enrolReferrer() {
+  func callConsumerApiEnrollment() {
 
     //Creating customer parameters with email , firstname and surname
     let parameters = MentionmeCustomerParameters(

--- a/MentionmeSwift.podspec
+++ b/MentionmeSwift.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'MentionmeSwift'
-  s.version          = '2.0'
+  s.version          = '2.1'
   s.summary          = 'Supercharge your customer growth with referral marketing through Mention Me'
 
 # This description is used to generate tags and improve search results.

--- a/MentionmeSwift/Classes/Requests/MentionmeReferrerEnrollmentRequest.swift
+++ b/MentionmeSwift/Classes/Requests/MentionmeReferrerEnrollmentRequest.swift
@@ -8,30 +8,14 @@
 
 import Foundation
 
-public class MentionmeReferrerEnrollmentRequest: MentionmeRequest {
-
-  override init() {
-    super.init()
-  }
+public class MentionmeReferrerEnrollmentRequest: MentionmeCustomerRequest {
 
   public convenience init(mentionmeCustomerParameters: MentionmeCustomerParameters) {
-
     self.init()
-
+      
     super.method = MethodType.post
     super.urlSuffix = "referrer"
     super.urlEndpoint = "entry-point"
-
+    super.mentionmeCustomerParameters = mentionmeCustomerParameters
   }
-
-  func createBodyParameters() {
-    bodyParameters = [String: Any]()
-  }
-
-  override func createRequest(requestParameters: MentionmeRequestParameters) -> NSMutableURLRequest
-  {
-    createBodyParameters()
-    return super.createRequest(requestParameters: requestParameters)
-  }
-
 }


### PR DESCRIPTION
When calling the EntryPoint API, we weren't including all the parameters and the segment was missing.